### PR TITLE
直接依頼時の挙動の変更

### DIFF
--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -46,6 +46,11 @@ body{
   font-weight: 600;
 }
 
+.page-description{
+  margin: 25px 0;
+  text-align: center;
+}
+
 /* サイトヘッダ */
 .site-header{
   display: flex;

--- a/app/controllers/commissions_controller.rb
+++ b/app/controllers/commissions_controller.rb
@@ -13,7 +13,7 @@ class CommissionsController < ApplicationController
     @commission = Commission.new(commission_param)
     if @commission.save
       if @commission.directly
-        redirect_to controller: :creators, action: :index, params: {"id" => @commission.id}
+        redirect_to select_commission_path(@commission)
       else
         redirect_to root_path
       end
@@ -25,13 +25,23 @@ class CommissionsController < ApplicationController
   def show
   end
 
+  def select
+    @creators = User.where(kind: 1).where.not(id: current_user.id)
+    @commission = Commission.find(params[:id])
+  end
+
+  def selected_confirmation
+    @commission = Commission.find(params[:id])
+    @creator = User.find(params[:user_id])
+  end
+
   def direct
     commission = Commission.find(params[:id])
     creator = User.find(params[:user_id])
     commission.contractor_id = creator.id
     commission.save
     Notification.create(user_id: creator.id, commission_id: commission.id)
-    redirect_to root_path
+    redirect_to root_path, flash: {direcly: "#{creator.user_name}さんに依頼しました"}
   end
 
   def unsuccessful

--- a/app/controllers/creators_controller.rb
+++ b/app/controllers/creators_controller.rb
@@ -2,7 +2,6 @@ class CreatorsController < ApplicationController
   def index
     user_id = user_signed_in? ? current_user.id : nil
     @creators = User.where(kind: 1).where.not(id: user_id)
-    @commission = Commission.find(params[:id]) if params.has_key?(:id)
   end
 
   def search

--- a/app/views/commissions/select.html.erb
+++ b/app/views/commissions/select.html.erb
@@ -1,0 +1,9 @@
+<h2 class="sub-title">制作者の選択</h2>
+
+<%= render partial: "creators/search_form" %>
+
+<div class="creators-list-container">
+  <div class="creators-list">
+    <%= render partial: "creators/creator", collection: @creators %>
+  </div>
+</div>

--- a/app/views/commissions/selected_confirmation.html.erb
+++ b/app/views/commissions/selected_confirmation.html.erb
@@ -1,0 +1,16 @@
+<h2 class="sub-title">確認</h2>
+<div class="confirmation">以下のユーザでよろしいですか？</div>
+
+<div class="page-description">直接依頼した場合、以下のユーザに通知されます。</div>
+
+<div class="user-profile-container">
+  <div class="user-profile">
+    <div class="user-info-item">ユーザ名 : <%= @creator.user_name %></div>
+    <div class="user-info-item">現在ランク : <%= @creator.rank %></div>
+  </div>
+</div>
+
+<div class="commission-select-button">
+  <%= link_to "はい", direct_commission_path(@commission, user_id: @creator.id), data:{turbo_method: :patch}, class: "button-orange" %>
+  <%= link_to "いいえ", select_commission_path(@commission), class: "button-gray" %>
+</div>

--- a/app/views/creators/_creator.html.erb
+++ b/app/views/creators/_creator.html.erb
@@ -3,7 +3,7 @@
   <div class="commission-select">
     <%= link_to "このユーザのプロフィールを見る", user_path(creator), class: "button-orange" %>
     <% if @commission %>
-      <%= link_to "このユーザに依頼する", direct_commission_path(@commission, user_id: creator.id), data: {turbo_method: :patch}, class: "button-orange" %>
+      <%= link_to "このユーザに依頼する", selected_confirmation_commission_path(@commission, user_id: creator.id), class: "button-orange" %>
     <% end %>
   </div>
 </div>

--- a/app/views/creators/_search_form.html.erb
+++ b/app/views/creators/_search_form.html.erb
@@ -1,10 +1,10 @@
 <div class="request-search">
-    <%= form_with url: search_creators_path, local: true, method: :get, class: "request-search-form" do |f| %>
-      <div class="form-upper">
-        <%= f.text_field :user_name, placeholder: "ここにユーザ名を入力", class: "search-input" %>
-      </div>
-      <div class="search-button-container">
-        <%= f.submit value: "検索", class: "search-button" %>
-      </div>
-    <% end %>
-  </div>
+  <%= form_with url: search_creators_path, local: true, method: :get, class: "request-search-form" do |f| %>
+    <div class="form-upper">
+      <%= f.text_field :user_name, placeholder: "ここにユーザ名を入力", class: "search-input" %>
+    </div>
+    <div class="search-button-container">
+      <%= f.submit value: "検索", class: "search-button" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/creators/index.html.erb
+++ b/app/views/creators/index.html.erb
@@ -1,4 +1,4 @@
-<h2 class="sub-title">製作者一覧</h2>
+<h2 class="sub-title">制作者一覧</h2>
 
 <%= render partial: "search_form" %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@ Rails.application.routes.draw do
   root to: "commissions#index"
   resources :commissions, only:[:index, :new, :create, :show] do
     member do
+      get "select"
+      get "selected_confirmation"
       patch "direct"
       get "unsuccessful"
     end


### PR DESCRIPTION
# What
依頼者が直接依頼を選択した際の挙動の改善

# Why
以前の状態では何のメッセージもなくトップページに戻るだけだったので、依頼ができたかどうかが分かり辛い為